### PR TITLE
Add clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,38 @@
+---
+Language: Cpp
+BasedOnStyle: Google
+
+ColumnLimit: 79
+UseTab: Never
+IndentWidth: 4
+IndentCaseLabels: false
+
+PointerAlignment: Left
+DerivePointerAlignment: false
+
+AccessModifierOffset: -4
+
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: true
+AlignConsecutiveAssignments: false
+
+AllowAllArgumentsOnNextLine: false
+AllowShortFunctionsOnASingleLine: InlineOnly
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+
+BreakConstructorInitializers: AfterColon
+BreakBeforeBinaryOperators: None
+BreakStringLiterals: true
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterClass: true
+
+SpaceBeforeCtorInitializerColon: false
+SpacesBeforeTrailingComments: 1
+
+SortIncludes: false
+SortUsingDeclarations: false
+
+Cpp11BracedListStyle: false
+PenaltyBreakAssignment: 2000

--- a/MasterIDExtension/include/scp/MasterIDExtension.h
+++ b/MasterIDExtension/include/scp/MasterIDExtension.h
@@ -26,42 +26,50 @@ namespace scp {
  *
  * @brief Master ID recording TLM extension
  *
- * @details Ignorable Extension type that can be used to add a Master ID (uint64_t).
- *          This is typically used for e.g. evaluating exclusive accesses.
+ * @details Ignorable Extension type that can be used to add a Master ID
+ * (uint64_t). This is typically used for e.g. evaluating exclusive accesses.
  */
 
-class MasterIDExtension : public tlm::tlm_extension<MasterIDExtension> {
+class MasterIDExtension : public tlm::tlm_extension<MasterIDExtension>
+{
     uint64_t m_id;
+
 public:
-    MasterIDExtension(uint64_t id) { m_id=id; }
+    MasterIDExtension(uint64_t id) { m_id = id; }
     MasterIDExtension(const MasterIDExtension&) = default;
 
-    virtual tlm_extension_base* clone() const override
-    {
+    virtual tlm_extension_base* clone() const override {
         return new MasterIDExtension(*this);
     }
 
-    virtual void copy_from(const tlm_extension_base& ext) override
-    {
-        const MasterIDExtension& other = static_cast<const MasterIDExtension&>(ext);
+    virtual void copy_from(const tlm_extension_base& ext) override {
+        const MasterIDExtension& other = static_cast<const MasterIDExtension&>(
+            ext);
         *this = other;
     }
 
-    operator uint64_t () {return m_id;};
+    operator uint64_t() { return m_id; };
 
-#define overload(_OP) MasterIDExtension& operator _OP(const uint64_t id){this->m_id _OP id; return *this; }
-overload(+=);
-overload(-=);
-overload(*=);
-overload(/=);
-overload(%=);
-overload(&=);
-overload(|=);
-overload(^=);
-overload(<<=);
-overload(>>=);
+#define overload(_OP)                                    \
+    MasterIDExtension& operator _OP(const uint64_t id) { \
+        this->m_id _OP id;                               \
+        return *this;                                    \
+    }
+    overload(+=);
+    overload(-=);
+    overload(*=);
+    overload(/=);
+    overload(%=);
+    overload(&=);
+    overload(|=);
+    overload(^=);
+    overload(<<=);
+    overload(>>=);
 
-    MasterIDExtension& operator=(const uint64_t id) {m_id=id; return *this;}
+    MasterIDExtension& operator=(const uint64_t id) {
+        m_id = id;
+        return *this;
+    }
 };
-}
+} // namespace scp
 #endif

--- a/PathTraceExtension/include/scp/PathTraceExtension.h
+++ b/PathTraceExtension/include/scp/PathTraceExtension.h
@@ -31,20 +31,21 @@ namespace scp {
  *          transactions as they pass through a network.
  */
 
-class PathTraceExtension : public tlm::tlm_extension<PathTraceExtension>, public std::vector<sc_core::sc_object*> {
+class PathTraceExtension : public tlm::tlm_extension<PathTraceExtension>,
+                           public std::vector<sc_core::sc_object*>
+{
 public:
     PathTraceExtension() = default;
     PathTraceExtension(const PathTraceExtension&) = default;
 
 public:
-    virtual tlm_extension_base* clone() const override
-    {
+    virtual tlm_extension_base* clone() const override {
         return new PathTraceExtension(*this);
     }
 
-    virtual void copy_from(const tlm_extension_base& ext) override
-    {
-        const PathTraceExtension& other = static_cast<const PathTraceExtension&>(ext);
+    virtual void copy_from(const tlm_extension_base& ext) override {
+        const PathTraceExtension&
+            other = static_cast<const PathTraceExtension&>(ext);
         *this = other;
     }
 
@@ -52,28 +53,23 @@ public:
      * @brief Stamp object into the PathTrace
      * @param obj  Object to add to the PathTrace
      */
-    void stamp(sc_core::sc_object* obj)
-    {
-        push_back(obj);
-    }
+    void stamp(sc_core::sc_object* obj) { push_back(obj); }
 
     /**
      * @brief Convenience function to special clear vector before stamping
      * @param obj  Object to add to the PathTrace
      */
-    void initiator_stamp(sc_core::sc_object* obj)
-    {
+    void initiator_stamp(sc_core::sc_object* obj) {
         clear();
         stamp(obj);
     }
     /**
      * @brief convert extension to a string
      * @param separator (default "->")
-     * @return a string consisting of the names of each object stamped into the path
-     *         separated with the separator provided.
+     * @return a string consisting of the names of each object stamped into the
+     * path separated with the separator provided.
      */
-    std::string to_string(std::string separator = "->")
-    {
+    std::string to_string(std::string separator = "->") {
         std::stringstream info;
         std::string s;
         for (auto o : *this) {
@@ -83,5 +79,5 @@ public:
         return info.str();
     }
 };
-}
+} // namespace scp
 #endif

--- a/tests/smoke.cc
+++ b/tests/smoke.cc
@@ -12,34 +12,31 @@
   implied.  See the License for the specific language governing
   permissions and limitations under the License.
  ****************************************************************************/
- 
+
 #include <scp/PathTraceExtension.h>
 #include <scp/MasterIDExtension.h>
 
 #include <systemc>
 #include <tlm>
 
-
-SC_MODULE(test)
-{
-    SC_CTOR(test){
-
+struct test : public sc_core::sc_module {
+    test(const sc_core::sc_module_name& nm): sc_module(nm) {
         scp::PathTraceExtension ext;
         ext.initiator_stamp(this);
-        SC_REPORT_INFO("ext test",ext.to_string().c_str());
+        SC_REPORT_INFO("ext test", ext.to_string().c_str());
 
         ext.initiator_stamp(this);
         ext.stamp(this);
         ext.stamp(this);
-        SC_REPORT_INFO("ext test",ext.to_string().c_str());
+        SC_REPORT_INFO("ext test", ext.to_string().c_str());
 
         scp::MasterIDExtension mid(0x1234);
-        mid=0x2345;
-        mid&=0xff;
-        mid<<=4;
-        uint64_t myint=mid+mid;
-        myint+=mid;
-        if (mid==0x450) {
+        mid = 0x2345;
+        mid &= 0xff;
+        mid <<= 4;
+        uint64_t myint = mid + mid;
+        myint += mid;
+        if (mid == 0x450) {
             SC_REPORT_INFO("ext test", "Success\n");
         } else {
             SC_REPORT_INFO("ext test", "Failour\n");
@@ -47,12 +44,9 @@ SC_MODULE(test)
     }
 };
 
-int sc_main(int argc, char **argv)
-{
+int sc_main(int argc, char** argv) {
     test test1("test");
 
     sc_core::sc_start();
     return 0;
 }
-
-

--- a/utils/check_format.sh
+++ b/utils/check_format.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+ ##############################################################################
+ #                                                                            #
+ # Copyright 2022 Lukas Jünger                                                #
+ #                                                                            #
+ # Licensed under the Apache License, Version 2.0 (the "License");            #
+ # you may not use this file except in compliance with the License.           #
+ # You may obtain a copy of the License at                                    #
+ #                                                                            #
+ #     http://www.apache.org/licenses/LICENSE-2.0                             #
+ #                                                                            #
+ # Unless required by applicable law or agreed to in writing, software        #
+ # distributed under the License is distributed on an "AS IS" BASIS,          #
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   #
+ # See the License for the specific language governing permissions and        #
+ # limitations under the License.                                             #
+ #                                                                            #
+ ##############################################################################
+
+source=$(find -name "*.h" -or -name "*.cc")
+exec clang-format --Werror $source $@


### PR DESCRIPTION
This commit adds clang-format and utility to run it. The smoke test was
refactored from using macros to using standard initialization to play
nicely with the format check.

Signed-off-by: Lukas Jünger <lukas@jngr.org>