### PR TITLE
Add clang-format workflow

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,0 +1,15 @@
+name: style
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  style:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Check code style
+      run: ./utils/check_format.sh -n

--- a/utils/check_format.sh
+++ b/utils/check_format.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+ ##############################################################################
+ #                                                                            #
+ # Copyright 2022 Lukas Jünger                                                #
+ #                                                                            #
+ # Licensed under the Apache License, Version 2.0 (the "License");            #
+ # you may not use this file except in compliance with the License.           #
+ # You may obtain a copy of the License at                                    #
+ #                                                                            #
+ #     http://www.apache.org/licenses/LICENSE-2.0                             #
+ #                                                                            #
+ # Unless required by applicable law or agreed to in writing, software        #
+ # distributed under the License is distributed on an "AS IS" BASIS,          #
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   #
+ # See the License for the specific language governing permissions and        #
+ # limitations under the License.                                             #
+ #                                                                            #
+ ##############################################################################
+
+source=$(find -name "*.h" -or -name "*.hpp" -or -name "*.c" -or -name "*.cc" -or -name "*.cpp")
+exec clang-format --Werror $source $@


### PR DESCRIPTION
This adds a clang-format CI workflow to check if all code conforms to
the code style.

Signed-off-by: Lukas Jünger <lukas@jngr.org>