### PR TITLE
Add logging cleanup API to fix Windows DLL unload hang

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,19 +40,27 @@ The macros take an optional argument which becomes the message type. If not is p
 
 ### Reporting backend
 
-The backend is initialized using the short form:
+The backend is initialized using `LoggingGuard` which automatically manages logging lifecycle using RAII:
 
+Short form:
 ```
-scp::init_logging(scp::log::INFO);
+scp::LoggingGuard guard(scp::log::INFO);
 ```
 
-or the long form
-
-``` 
-scp::init_logging(scp::LogConfig()
+Long form with configuration:
+```
+scp::LoggingGuard guard(scp::LogConfig()
 		.logLevel(scp::log::DEBUG) // set log level to debug
 		.msgTypeFieldWidth(10));   // make the msg type column a bit tighter
 ```
 
-which allows more configurability. For detail please check the header file report.h
-In both case an alternate report handler is installed which which uses a tabular format and spdlog for writing. By default spdlog logs asyncronously to keep the performance impact low.
+The `LoggingGuard` ensures proper cleanup when it goes out of scope, preventing resource leaks and Windows DLL unload hangs. For detail please check the header file report.h
+
+Alternatively, you can still use the manual approach with `init_logging()` and `shutdown_logging()`:
+```
+scp::init_logging(scp::log::INFO);
+// ... your code ...
+scp::shutdown_logging();
+```
+
+In both cases an alternate report handler is installed which uses a tabular format and spdlog for writing. By default spdlog logs asynchronously to keep the performance impact low.

--- a/examples/smoke_report.cc
+++ b/examples/smoke_report.cc
@@ -144,7 +144,7 @@ int sc_main(int argc, char** argv) {
 
     std::string logfile = "/tmp/scp_smoke_report_test." +
                           std::to_string(getpid());
-    scp::init_logging(
+    scp::LoggingGuard logging_guard(
         scp::LogConfig()
             .logLevel(scp::log::DEBUG) // set log level to debug
             .msgTypeFieldWidth(20)

--- a/report/README.md
+++ b/report/README.md
@@ -129,18 +129,20 @@ Hence a module of type `mymod`, instanced with hierarchical name `top.foo` with 
 
 
 ## Initialization
+
+### Recommended: Using LoggingGuard (RAII)
 ```C
-   scp::init_logging(config)
+   scp::LoggingGuard guard(config);
 ```
-This is an optional function which enables the more complex logging mechanisms. Without it, only basic logging is possible. This takes a configuration structure as a parameter.
+This is the recommended approach which automatically handles initialization and cleanup. The guard ensures that `shutdown_logging()` is called when it goes out of scope, preventing resource leaks and Windows DLL unload hangs.
 
 The configuration structure can be constructed simply:
 ```C
     scp::LogConfig()
 ```
-Convenience functions are provided on a configuration structure that return a modified structure, hence  for example:
+Convenience functions are provided on a configuration structure that return a modified structure, hence for example:
 ```C
-    scp::init_logging(
+    scp::LoggingGuard guard(
         scp::LogConfig()
             .logLevel(scp::log::DEBUG)
             .msgTypeFieldWidth(20)
@@ -149,6 +151,14 @@ Convenience functions are provided on a configuration structure that return a mo
             .printSimTime(false)
             .logFileName(logfile));
 ```
+
+### Alternative: Manual initialization
+```C
+   scp::init_logging(config);
+   // ... your code ...
+   scp::shutdown_logging();
+```
+If you use `init_logging()` directly, you MUST call `shutdown_logging()` before application exit to properly clean up logging resources.
 
 | Use                                                        |   method                                   |  Default
 | ---- | ---- | --- |

--- a/report/src/report.cpp
+++ b/report/src/report.cpp
@@ -464,6 +464,22 @@ void scp::set_cycle_base(sc_core::sc_time period) {
     log_cfg.cycle_base = period;
 }
 
+void scp::shutdown_logging() {
+    // Flush all loggers before shutdown
+    if (log_cfg.console_logger) {
+        log_cfg.console_logger->flush();
+    }
+    if (log_cfg.file_logger) {
+        log_cfg.file_logger->flush();
+    }
+
+    // Drop all spdlog loggers to release resources
+    spdlog::drop_all();
+
+    // Shutdown the thread pool - this will join all worker threads
+    spdlog::shutdown();
+}
+
 auto scp::LogConfig::logLevel(scp::log level) -> scp::LogConfig& {
     this->level = level;
     return *this;


### PR DESCRIPTION
Adds shutdown_logging() function and LoggingGuard RAII wrapper to properly clean up spdlog resources before application exit. This prevents a deadlock during static destruction on Windows where the thread pool destructor attempts to destroy synchronization primitives while worker threads are still blocked.

The shutdown_logging() function flushes pending messages, drops all loggers, and shuts down the spdlog thread pool to ensure worker threads are properly joined before static destructors run.

LoggingGuard provides a RAII wrapper for automatic cleanup, eliminating the need for manual shutdown_logging() calls. It offers two constructors covering all init_logging() use cases:
- LoggingGuard(log level, unsigned width, bool time)
- LoggingGuard(const LogConfig& config)

Updated documentation and examples to recommend LoggingGuard as the preferred approach while maintaining manual init/shutdown as alternative.